### PR TITLE
Make 32-bit drivers buildable again

### DIFF
--- a/build/VStudio/winfsp_sys.vcxproj
+++ b/build/VStudio/winfsp_sys.vcxproj
@@ -101,6 +101,7 @@
     <EnableInf2cat>false</EnableInf2cat>
     <OutDir>$(SolutionDir)build\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)build\$(ProjectName).build\$(Configuration)\$(MyProductFileArch)\</IntDir>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -108,6 +109,7 @@
     <EnableInf2cat>false</EnableInf2cat>
     <OutDir>$(SolutionDir)build\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)build\$(ProjectName).build\$(Configuration)\$(MyProductFileArch)\</IntDir>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>

--- a/inc/fuse/fuse_common.h
+++ b/inc/fuse/fuse_common.h
@@ -107,7 +107,7 @@ struct fuse_file_info
     unsigned int flush:1;
     unsigned int nonseekable:1;
     unsigned int padding:28;
-    uint64_t fh;
+    uintptr_t fh;
     uint64_t lock_owner;
 };
 

--- a/inc/fuse3/fuse_common.h
+++ b/inc/fuse3/fuse_common.h
@@ -87,7 +87,7 @@ struct fuse3_file_info
     unsigned int nonseekable:1;
     unsigned int flock_release:1;
     unsigned int padding:27;
-    uint64_t fh;
+    uintptr_t fh;
     uint64_t lock_owner;
     uint32_t poll_events;
 };

--- a/src/dll/fuse/library.h
+++ b/src/dll/fuse/library.h
@@ -86,7 +86,7 @@ struct fsp_fuse_file_desc
     char *PosixPath;
     BOOLEAN IsDirectory, IsReparsePoint;
     int OpenFlags;
-    UINT64 FileHandle;
+    UINT_PTR FileHandle;
     PVOID DirBuffer;
 };
 struct fuse_dirhandle


### PR DESCRIPTION
This patch restores the ability to build 32-bit drivers, by retargeting winfsp_sys Win32 builds back towards Windows 10.
The AMD64 and ARM64 builds are not affected.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [ ] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
